### PR TITLE
A number of fixes

### DIFF
--- a/src/net/Acceptor.cpp
+++ b/src/net/Acceptor.cpp
@@ -26,7 +26,7 @@ int Acceptor::Listen(std::string ip, uint16_t port)
 	}
 
 	SOCKET sockfd = tcp_socket_->Create();
-	channel_ptr_.reset(new Channel(sockfd));
+	channel_ptr_.reset(new Channel(sockfd, ip, port));
 	SocketUtil::SetReuseAddr(sockfd);
 	SocketUtil::SetReusePort(sockfd);
 	SocketUtil::SetNonBlock(sockfd);
@@ -59,13 +59,13 @@ void Acceptor::OnAccept()
 {
 	std::lock_guard<std::mutex> locker(mutex_);
 
-	SOCKET connfd = tcp_socket_->Accept();
-	if (connfd > 0) {
+	auto ret = tcp_socket_->Accept();
+	if (std::get<0>(ret) > 0) {
 		if (new_connection_callback_) {
-			new_connection_callback_(connfd);
+			new_connection_callback_(std::get<0>(ret), std::get<1>(ret), std::get<2>(ret));
 		}
 		else {
-			SocketUtil::Close(connfd);
+			SocketUtil::Close(std::get<0>(ret));
 		}
 	}
 }

--- a/src/net/Acceptor.h
+++ b/src/net/Acceptor.h
@@ -10,7 +10,7 @@
 namespace xop
 {
 
-typedef std::function<void(SOCKET)> NewConnectionCallback;
+typedef std::function<void(SOCKET, std::string, int)> NewConnectionCallback;
 
 class EventLoop;
 

--- a/src/net/BufferWriter.h
+++ b/src/net/BufferWriter.h
@@ -31,13 +31,13 @@ public:
 	int Send(SOCKET sockfd, int timeout=0);
 
 	bool IsEmpty() const 
-	{ return buffer_->empty(); }
+	{ return buffer_.empty(); }
 
 	bool IsFull() const 
-	{ return ((int)buffer_->size() >= max_queue_length_ ? true : false); }
+	{ return ((int)buffer_.size() >= max_queue_length_ ? true : false); }
 
 	uint32_t Size() const 
-	{ return (uint32_t)buffer_->size(); }
+	{ return (uint32_t)buffer_.size(); }
 	
 private:
 	typedef struct 
@@ -47,7 +47,7 @@ private:
 		uint32_t writeIndex;
 	} Packet;
 
-	std::shared_ptr<std::queue<Packet>> buffer_;  		
+	std::queue<Packet> buffer_;  		
 	int max_queue_length_ = 0;
 	 
 	static const int kMaxQueueLength = 10000;

--- a/src/net/Channel.h
+++ b/src/net/Channel.h
@@ -28,7 +28,7 @@ public:
 	typedef std::function<void()> EventCallback;
     
 	Channel() = delete;
-	Channel(SOCKET sockfd) : sockfd_(sockfd) {};
+	Channel(SOCKET sockfd, std::string ip, uint16_t port) : sockfd_(sockfd), ip_(ip), port_(port) {};
 	virtual ~Channel() {};
     
 	void SetReadCallback(const EventCallback& cb)
@@ -44,6 +44,8 @@ public:
 	{ error_callback_ = cb; }
 
 	SOCKET GetSocket() const { return sockfd_; }
+        const std::string& GetIp() const { return ip_; }
+        uint16_t GetPort() const { return port_; }
 
 	int  GetEvents() const { return events_; }
 	void SetEvents(int events) { events_ = events; }
@@ -91,6 +93,8 @@ private:
 	EventCallback error_callback_ = []{};
     
 	SOCKET sockfd_ = 0;
+        const std::string ip_;
+        const uint16_t    port_;
 	int events_ = 0;    
 };
 

--- a/src/net/EventLoop.cpp
+++ b/src/net/EventLoop.cpp
@@ -69,7 +69,7 @@ void EventLoop::Loop()
 		threads_.push_back(thread);
 	}
 
-	int priority = TASK_SCHEDULER_PRIORITY_REALTIME;
+	const int priority = TASK_SCHEDULER_PRIORITY_REALTIME;
 
 	for (auto iter : threads_) 
 	{

--- a/src/net/MemoryManager.cpp
+++ b/src/net/MemoryManager.cpp
@@ -52,8 +52,6 @@ void MemoryPool::Init(uint32_t size, uint32_t n)
 
 void* MemoryPool::Alloc(uint32_t size)
 {
-	MemoryBlock* block = nullptr;
-
 	std::lock_guard<std::mutex> locker(mutex_);
 	if (head_ != nullptr) {
 		MemoryBlock* block = head_;

--- a/src/net/RingBuffer.h
+++ b/src/net/RingBuffer.h
@@ -17,9 +17,9 @@ class RingBuffer
 {
 public:
 	RingBuffer(unsigned capacity=60)
-		: _buffer(capacity)
-		, _capacity(capacity)
+		: _capacity(capacity)
 		, _numDatas(0)
+                , _buffer(capacity)
 	{ }
 	
 	~RingBuffer() {	}

--- a/src/net/TaskScheduler.cpp
+++ b/src/net/TaskScheduler.cpp
@@ -22,7 +22,7 @@ TaskScheduler::TaskScheduler(int id)
 	});
 
 	if (wakeup_pipe_->Create()) {
-		wakeup_channel_.reset(new Channel(wakeup_pipe_->Read()));
+		wakeup_channel_.reset(new Channel(wakeup_pipe_->Read(),"pip", -1));
 		wakeup_channel_->EnableReading();
 		wakeup_channel_->SetReadCallback([this]() { this->Wake(); });		
 	}        

--- a/src/net/TcpConnection.cpp
+++ b/src/net/TcpConnection.cpp
@@ -3,11 +3,11 @@
 
 using namespace xop;
 
-TcpConnection::TcpConnection(TaskScheduler *task_scheduler, SOCKET sockfd)
+TcpConnection::TcpConnection(TaskScheduler *task_scheduler, SOCKET sockfd, std::string ip, int port)
 	: task_scheduler_(task_scheduler)
 	, read_buffer_(new BufferReader)
 	, write_buffer_(new BufferWriter(500))
-	, channel_(new Channel(sockfd))
+	, channel_(new Channel(sockfd, ip, port))
 {
 	is_closed_ = false;
 

--- a/src/net/TcpConnection.h
+++ b/src/net/TcpConnection.h
@@ -19,7 +19,7 @@ public:
 	using CloseCallback = std::function<void(std::shared_ptr<TcpConnection> conn)>;
 	using ReadCallback = std::function<bool(std::shared_ptr<TcpConnection> conn, xop::BufferReader& buffer)>;
 
-	TcpConnection(TaskScheduler *task_scheduler, SOCKET sockfd);
+	TcpConnection(TaskScheduler *task_scheduler, SOCKET sockfd, std::string ip, int port);
 	virtual ~TcpConnection();
 
 	TaskScheduler* GetTaskScheduler() const 
@@ -41,6 +41,16 @@ public:
 
 	SOCKET GetSocket() const
 	{ return channel_->GetSocket(); }
+
+        int GetPort() const
+        {
+            return channel_->GetPort();
+        }
+    
+        const std::string& GetIp() const
+        {
+            return channel_->GetIp();
+        }
 
 protected:
 	friend class TcpServer;

--- a/src/net/TcpServer.cpp
+++ b/src/net/TcpServer.cpp
@@ -13,8 +13,8 @@ TcpServer::TcpServer(EventLoop* event_loop)
 	, acceptor_(new Acceptor(event_loop_))
 	, is_started_(false)
 {
-	acceptor_->SetNewConnectionCallback([this](SOCKET sockfd) {
-		TcpConnection::Ptr conn = this->OnConnect(sockfd);
+	acceptor_->SetNewConnectionCallback([this](SOCKET sockfd, std::string ip, int port) {
+		TcpConnection::Ptr conn = this->OnConnect(sockfd, ip, port);
 		if (conn) {
 			this->AddConnection(sockfd, conn);
 			conn->SetDisconnectCallback([this](TcpConnection::Ptr conn) {
@@ -73,9 +73,9 @@ void TcpServer::Stop()
 	}	
 }
 
-TcpConnection::Ptr TcpServer::OnConnect(SOCKET sockfd)
+TcpConnection::Ptr TcpServer::OnConnect(SOCKET sockfd, std::string ip, int port)
 {
-	return std::make_shared<TcpConnection>(event_loop_->GetTaskScheduler().get(), sockfd);
+	return std::make_shared<TcpConnection>(event_loop_->GetTaskScheduler().get(), sockfd, ip, port);
 }
 
 void TcpServer::AddConnection(SOCKET sockfd, TcpConnection::Ptr tcpConn)

--- a/src/net/TcpServer.h
+++ b/src/net/TcpServer.h
@@ -33,7 +33,7 @@ public:
 	{ return port_; }
 
 protected:
-	virtual TcpConnection::Ptr OnConnect(SOCKET sockfd);
+	virtual TcpConnection::Ptr OnConnect(SOCKET sockfd, std::string ip, int port);
 	virtual void AddConnection(SOCKET sockfd, TcpConnection::Ptr tcpConn);
 	virtual void RemoveConnection(SOCKET sockfd);
 

--- a/src/net/TcpSocket.cpp
+++ b/src/net/TcpSocket.cpp
@@ -52,14 +52,19 @@ bool TcpSocket::Listen(int backlog)
 	return true;
 }
 
-SOCKET TcpSocket::Accept()
+std::tuple<SOCKET,std::string,int> TcpSocket::Accept()
 {
 	struct sockaddr_in addr = {0};
 	socklen_t addrlen = sizeof addr;
 
-	SOCKET clientfd = ::accept(sockfd_, (struct sockaddr*)&addr, &addrlen);
-
-	return clientfd;
+        std::tuple<SOCKET,std::string,int> ret;
+	std::get<0>(ret) = ::accept(sockfd_, (struct sockaddr*)&addr, &addrlen);
+        if (std::get<0>(ret) > 0)
+        {
+            std::get<1>(ret) = inet_ntoa(addr.sin_addr);
+            std::get<2>(ret) = htons(addr.sin_port);
+        }
+	return ret;
 }
 
 bool TcpSocket::Connect(std::string ip, uint16_t port, int timeout)

--- a/src/net/TcpSocket.h
+++ b/src/net/TcpSocket.h
@@ -20,7 +20,7 @@ public:
 	SOCKET Create();
 	bool Bind(std::string ip, uint16_t port);
 	bool Listen(int backlog);
-	SOCKET Accept();
+	std::tuple<SOCKET,std::string,int> Accept();
 	bool Connect(std::string ip, uint16_t port, int timeout = 0);
 	void Close();
 	void ShutdownWrite();

--- a/src/net/Timer.h
+++ b/src/net/Timer.h
@@ -103,7 +103,7 @@ private:
 	std::unordered_map<TimerId, std::shared_ptr<Timer>> timers_;
 	std::map<std::pair<int64_t, TimerId>, std::shared_ptr<Timer>> events_;
 	uint32_t last_timer_id_ = 0;
-	uint32_t time_remaining_ = 0;
+//	uint32_t time_remaining_ = 0;
 };
 
 }

--- a/src/xop/MediaSession.h
+++ b/src/xop/MediaSession.h
@@ -29,7 +29,8 @@ class RtpConnection;
 class MediaSession
 {
 public:
-    typedef std::function<void (MediaSessionId sessionId, uint32_t numClients)> NotifyCallback;
+    typedef std::function<void (MediaSessionId sessionId, uint32_t numClients, std::string ip)> NotifyConnectedCallback;
+    typedef std::function<void (MediaSessionId sessionId, uint32_t numClients, std::string ip)> NotifyDisconnectedCallback;
 
     static MediaSession* CreateNew(std::string url_suffxx="live");
     ~MediaSession();
@@ -39,8 +40,8 @@ public:
 
     bool StartMulticast();
 
-    void SetNotifyCallback(const NotifyCallback& cb)
-    { notify_callback_ = cb; }
+    void addNotifyConnectedCallback(const NotifyConnectedCallback& cb);
+    void addNotifyDisconnectedCallback(const NotifyDisconnectedCallback& cb);
 
     std::string GetRtspUrlSuffix() const
     { return suffix_; }
@@ -89,7 +90,8 @@ private:
     std::vector<std::unique_ptr<MediaSource>> media_sources_;
     std::vector<RingBuffer<AVFrame>> _buffer;
 
-    NotifyCallback notify_callback_;
+    std::vector<NotifyConnectedCallback> _notifyConnectedCallbacks;
+    std::vector<NotifyDisconnectedCallback> _notifyDisconnectedCallbacks;
     std::mutex mutex_;
     std::mutex map_mutex_;
     std::map<SOCKET, std::weak_ptr<RtpConnection>> clients_;

--- a/src/xop/RtpConnection.h
+++ b/src/xop/RtpConnection.h
@@ -19,6 +19,13 @@ namespace xop
 
 class RtspConnection;
 
+struct sockInfo
+{
+    SOCKET      fd;
+    std::string ip;
+    uint16_t    port;
+};
+
 class RtpConnection
 {
 public:
@@ -44,9 +51,15 @@ public:
     uint16_t GetRtcpPort(MediaChannelId channel_id) const
     { return local_rtcp_port_[channel_id]; }
 
-    SOCKET GetRtcpfd(MediaChannelId channel_id)
+    sockInfo GetRtcpSockInfo(MediaChannelId channel_id)
     { return rtcpfd_[channel_id]; }
 
+    std::string GetIp()
+    { 
+        auto conn = rtsp_connection_.lock();
+        return conn ? conn->GetIp() : "";
+    }
+    
     bool IsMulticast() const
     { return is_multicast_; }
 

--- a/src/xop/RtspConnection.h
+++ b/src/xop/RtspConnection.h
@@ -42,7 +42,7 @@ public:
 	};
 
 	RtspConnection() = delete;
-	RtspConnection(std::shared_ptr<Rtsp> rtsp_server, TaskScheduler *task_scheduler, SOCKET sockfd);
+	RtspConnection(std::shared_ptr<Rtsp> rtsp_server, TaskScheduler *task_scheduler, SOCKET sockfd, std::string ip, int port);
 	~RtspConnection();
 
 	MediaSessionId GetMediaSessionId()

--- a/src/xop/RtspServer.cpp
+++ b/src/xop/RtspServer.cpp
@@ -97,8 +97,8 @@ bool RtspServer::PushFrame(MediaSessionId sessionId, MediaChannelId channelId, A
     return false;
 }
 
-TcpConnection::Ptr RtspServer::OnConnect(SOCKET sockfd)
+TcpConnection::Ptr RtspServer::OnConnect(SOCKET sockfd, std::string ip, int port)
 {	
-	return std::make_shared<RtspConnection>(shared_from_this(), event_loop_->GetTaskScheduler().get(), sockfd);
+	return std::make_shared<RtspConnection>(shared_from_this(), event_loop_->GetTaskScheduler().get(), sockfd, ip, port);
 }
 

--- a/src/xop/RtspServer.h
+++ b/src/xop/RtspServer.h
@@ -33,7 +33,7 @@ private:
 	RtspServer(xop::EventLoop* loop);
     MediaSessionPtr LookMediaSession(const std::string& suffix);
     MediaSessionPtr LookMediaSession(MediaSessionId sessionId);
-    virtual TcpConnection::Ptr OnConnect(SOCKET sockfd);
+    virtual TcpConnection::Ptr OnConnect(SOCKET sockfd, std::string ip, int port);
 
     std::mutex mutex_;
     std::unordered_map<MediaSessionId, std::shared_ptr<MediaSession>> media_sessions_;

--- a/src/xop/media.h
+++ b/src/xop/media.h
@@ -31,7 +31,7 @@ enum FrameType
 struct AVFrame
 {	
 	AVFrame(uint32_t size = 0)
-		:buffer(new uint8_t[size + 1])
+		:buffer(new uint8_t[size + 1], std::default_delete<uint8_t[]>())
 	{
 		this->size = size;
 		type = 0;

--- a/src/xop/rtp.h
+++ b/src/xop/rtp.h
@@ -64,7 +64,7 @@ struct MediaChannelInfo
 struct RtpPacket
 {
 	RtpPacket()
-		: data(new uint8_t[1600])
+		: data(new uint8_t[1600], std::default_delete<uint8_t[]>())
 	{
 		type = 0;
 	}


### PR DESCRIPTION
This PR fixes a number of memory leaks associated with using shared_ptr as a buffer. You need to use the right deleter. 
Sockets now have IP address and port information which can be propagated to callbacks. 
The notifycallback is split into connected and disconnected callbacks for clarity. 
I don't see why std::shared_ptr<std::queue<>> is required when that queue isn't shared anywhere.
So this PR contains a few fixes here and there.