### PR TITLE
fixed:delete m_buf array

### DIFF
--- a/example/rtsp_h264_file.cpp
+++ b/example/rtsp_h264_file.cpp
@@ -120,7 +120,7 @@ H264File::H264File(int buf_size)
 
 H264File::~H264File()
 {
-	delete m_buf;
+	delete [] m_buf;
 }
 
 bool H264File::Open(const char *path)


### PR DESCRIPTION
这里应该是使用delete[] 释放吧，前面是使用 new char[m_buf_size]  申请的内存。